### PR TITLE
Added 'RDataTmp' files to Rbuildignore and .gitignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
 ^.DS_Store$
+^.RDataTmp$

--- a/.github/workflows/pushrelease.yml
+++ b/.github/workflows/pushrelease.yml
@@ -81,6 +81,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
+          DEFAULT_BUMP: patch
           RELEASE_BRANCHES: main
 
       - name: Checkout two

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ docs
 *.DS_Store
 inst/.DS_Store
 CRAN-SUBMISSION
-.RDataTmp
+*.RDataTmp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: manydata
 Title: A Portal for Global Governance Data
-Version: 0.8.0
-Date: 2022-11-10
+Version: 0.8.1
+Date: 2022-11-11
 Authors@R:
     c(person(given = "James",
              family = "Hollway",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# manydata 0.8.1
+
+## Package
+
+* Added 'RDataTmp' files to Rbuildignore and .gitignore
+
 # manydata 0.8.0
 
 ## Package

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,8 +1,3 @@
-This is a resubmission. In this version I have:
-
-* Removed `{skimr}` table from `emperors` database documentation
-* Updated path for binaries in push release GitHub actions
-
 ## Test environments
 
 * local R installation, x86_64-apple-darwin17.0, R 4.2.0

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,7 @@
+This is a resubmission. In this version I have:
+
+* Added 'RDataTmp' files to Rbuildignore and .gitignore
+
 ## Test environments
 
 * local R installation, x86_64-apple-darwin17.0, R 4.2.0


### PR DESCRIPTION
# Description

These patch changes fix issues with 'RDataTmp' files for CRAN submission.

## Package

* Added 'RDataTmp' files to Rbuildignore and .gitignore

# Checklist:

- [ ] PR form
  - [ ] I have given this pull request an informative title
  - [ ] Description above itemizes changes under subtitles, e.g. "## Collection""
  - [ ] Any closed, fixed, or related issues are referenced and explained in the description above, e.g. "Fixed #0 by adding A"
  - [ ] Package builds on my OS without issues
- [ ] PR checks all pass for latest commit
  - [ ] Package builds on Mac
  - [ ] Package builds on Windows
  - [ ] Package builds on Linux
  - [ ] CodeCov check: Package improves or maintains good test coverage
  - [ ] CodeFactor check: Package improves or maintains good style
- [ ] Documentation
  - [ ] Any new or modified functions or data have roxygen style documentation in their .R scripts
  - [ ] Any longer functions are commented inline so that it is easier to debug in the future
  - [ ] PR description above and the NEWS.md file are aligned
  - [ ] DESCRIPTION file version is bumped by the appropriate increment (major, minor, patch)
